### PR TITLE
Fix GetCurrentProcess variable assignment mismatch

### DIFF
--- a/privilege.go
+++ b/privilege.go
@@ -126,7 +126,7 @@ func enableDisableProcessPrivilege(names []string, action uint32) error {
 		return err
 	}
 
-	p, _ := windows.GetCurrentProcess()
+	p := windows.GetCurrentProcess()
 	var token windows.Token
 	err = windows.OpenProcessToken(p, windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, &token)
 	if err != nil {


### PR DESCRIPTION
Function `GetCurrentProcess`'s return value changed from `(pseudoHandle Handle, err error)` to `(pseudoHandle Handle)` only